### PR TITLE
Fix error when `addons` is not empty

### DIFF
--- a/pyUltroid/startup/loader.py
+++ b/pyUltroid/startup/loader.py
@@ -8,6 +8,7 @@
 
 from decouple import config
 from git import Repo
+from shutil import rmtree
 
 from .. import *
 from ..dB._core import HELP
@@ -58,7 +59,7 @@ def load_other_plugins(addons=None, pmbot=None, manager=None, vcbot=None):
         if url:
             os.system("git clone -q {} addons".format(url))
         if os.path.exists("addons") and not os.path.exists("addons/.git"):
-            os.rmdir("addons")
+            rmtree("addons")
         if not os.path.exists("addons"):
             os.system(
                 f"git clone -q -b {Repo().active_branch} https://github.com/TeamUltroid/UltroidAddons.git addons"


### PR DESCRIPTION
If the folder `addons` is not empty, `os.remove` will raise an error. `shutil.rmtree` will try to delete the entire folder tree.